### PR TITLE
Bumps up compat entry for `DynamicalSystemsBase.jl``

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystems"
 uuid = "61744808-ddfa-5f27-97ff-6e42cc95d634"
 repo = "https://github.com/JuliaDynamics/DynamicalSystems.jl.git"
-version = "1.7.7"
+version = "1.7.8"
 
 [deps]
 ChaosTools = "608a59af-f2a3-5ad4-90b4-758bdf3122a7"
@@ -15,7 +15,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 ChaosTools = "1.28"
 DelayEmbeddings = "1.13"
-DynamicalSystemsBase = "1.6"
+DynamicalSystemsBase = "^1.8"
 Entropies = "0.11"
 RecurrenceAnalysis = "1.5.0"
 Reexport = "0.2, 0.3, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 ChaosTools = "1.28"
 DelayEmbeddings = "1.13"
-DynamicalSystemsBase = "^1.8"
+DynamicalSystemsBase = "1.8"
 Entropies = "0.11"
 RecurrenceAnalysis = "1.5.0"
 Reexport = "0.2, 0.3, 1"


### PR DESCRIPTION
This PR bumps up the compat entry for `DynamicalSystemsBase.jl` which seems to be pinned at v1.6.

I suggest registering the new minor release after both #138 (e.g. via #139) and also #141 are resolved.

Closes #141.