### PR TITLE
functions need to be terminated and return a NaN value when the integrator detects instability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 ![DynamicalSystems.jl logo: The Double Pendulum](https://i.imgur.com/nFQFdB0.gif)
 
-| **Documentation** | Gitter | DocBuild | Citing |
-|:--------:|:-----:|:-----:|:----:|
-|[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaDynamics.github.io/DynamicalSystems.jl/dev) | [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/JuliaDynamics/Lobby) | [![DocBuild](https://github.com/juliadynamics/DynamicalSystems.jl/workflows/CI/badge.svg)](https://github.com/JuliaDynamics/DynamicalSystems.jl/actions) | [![DOI](http://joss.theoj.org/papers/10.21105/joss.00598/status.svg)](https://doi.org/10.21105/joss.00598)
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaDynamics.github.io/DynamicalSystems.jl/dev)
+[![DocBuild](https://github.com/juliadynamics/DynamicalSystems.jl/workflows/CI/badge.svg)](https://github.com/JuliaDynamics/DynamicalSystems.jl/actions)
+[![DOI](http://joss.theoj.org/papers/10.21105/joss.00598/status.svg)](https://doi.org/10.21105/joss.00598)
+[![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/DynamicalSystems)](https://pkgs.genieframework.com?packages=DynamicalSystems)
 
 **DynamicalSystems.jl** is an award-winning Julia software library for the exploration of chaos and nonlinear dynamics. The current repository holds the documentation and exports *all* relevant packages.
 **For installation instructions, full content overview and detailed documentation, [click here](https://juliadynamics.github.io/DynamicalSystems.jl/latest/).**


### PR DESCRIPTION
Functions that may loop over initial conditions and/or parameter values should be terminated when instability comes and then return a ```NaN``` value, for example the ```lyapunovspectrum``` and the ```lyapunov```.