### PR TITLE
Fixed Makie error in interactive_orbitdiagram

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystems"
 uuid = "61744808-ddfa-5f27-97ff-6e42cc95d634"
 repo = "https://github.com/JuliaDynamics/DynamicalSystems.jl.git"
-version = "3.3.15"
+version = "3.3.16"
 
 [deps]
 Attractors = "f3fd9213-ca85-4dba-9dfd-7fc91308fec7"

--- a/Project.toml
+++ b/Project.toml
@@ -44,7 +44,7 @@ julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [targets]
-test = ["Test", "GLMakie"]
+test = ["Test", "Makie"]

--- a/ext/src/orbitdiagram.jl
+++ b/ext/src/orbitdiagram.jl
@@ -5,13 +5,11 @@ function DynamicalSystems.interactive_orbitdiagram(ds, p_index, p_min, p_max, i0
     )
 
     figure = Figure(size = (1200, 600))
-    # display(figure)
     odax = figure[1,1] = Axis(figure; title)
     for z in (:xpanlock, :ypanlock, :xzoomlock, :yzoomlock)
         setproperty!(odax, z, true)
     end
     controllayout = figure[1, 2] = GridLayout()
-    # display(figure)
 
     controllayout.tellheight[] = false
     odax.tellheight = true
@@ -140,7 +138,6 @@ function minimal_normalized_od(ds, i, p_index, p₋, p₊,
 
     pvalues = range(p₋, stop = p₊, length = d)
     pdif = p₊ - p₋
-    # od = Vector{Point2f}() # make this pre-allocated
     od = Vector{Point2f}(undef, d*n)
     xmin = eltype(current_state(ds))(Inf)
     xmax = eltype(current_state(ds))(-Inf)
@@ -153,7 +150,6 @@ function minimal_normalized_od(ds, i, p_index, p₋, p₊,
         for _ in 1:n
             step!(ds)
             x = current_state(ds)[i]
-            # push!(od, Point2f(pp, x))
             od[count] = Point2f(pp, x)
 
             # update limits

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using DynamicalSystems, Test, GLMakie
+using DynamicalSystems, Test, Makie
 
 @testset "Interactive Orbit Diagram" begin
     ps = Dict(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using DynamicalSystems, Test, Makie
 
     ds = PredefinedDynamicalSystems.lorenz()
 
-    interactive_orbitdiagram(ds, 1, 1.0, 3.0)
+    fig, _ = interactive_orbitdiagram(ds, 1, 1.0, 3.0)
+    @test fig isa Makie.Figure
 end
 


### PR DESCRIPTION
I fixed the `Makie.Layout` error I raised in #237 by removing that qualifier from the `deactivate_interaction!` call. 

### Other changes that can be ommitted upon review

- I removed some `display(figure)` calls because they seemed unnecessary and aren't shared by the other interactive plotting scripts. 
- I preallocated the `Vector{Point2f}` in the first `minimal_normalized_od` method because the length is known at compile time (the other method has conditional push so left it as is)
- Finally, I added a testset and a test for calling this plotting function. Not sure if you guys don't use a `Test.jl` based CI for a reason or was just never implemented. The test fails with an error with the prior code but passes now.