### PR TITLE
remove unused subscript variable from DynamicalSystemsVisualizations …

### DIFF
--- a/ext/DynamicalSystemsVisualizations.jl
+++ b/ext/DynamicalSystemsVisualizations.jl
@@ -11,6 +11,4 @@ include("src/orbitdiagram.jl")
 include("src/brainscan.jl")
 include("src/2dclicker.jl")
 
-subscript = DynamicalSystemsVisualizations.subscript
-
 end


### PR DESCRIPTION
Resolves https://github.com/JuliaDynamics/DynamicalSystems.jl/issues/258.
This PR just removed ```subscript = DynamicalSystemsVisualizations.subscript``` from ext/DynamicalSystemsVisualizations.jl, which was somehow added in this commit https://github.com/JuliaDynamics/DynamicalSystems.jl/commit/e8f39af0bdbf0d5704b3678d7f9706c2b7fde835